### PR TITLE
Make GitHub Latest work with design update as part of preview feature

### DIFF
--- a/GitHub_Latest.meta.js
+++ b/GitHub_Latest.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        GitHub Latest
 // @namespace   https://github.com/Ede123/userscripts
-// @version     1.0.8
+// @version     1.1.0
 // @description Always keep an eye on the latest activity of your favorite projects
 // @icon        https://raw.githubusercontent.com/Ede123/userscripts/master/icons/GitHub.png
 // @author      Eduard Braun <eduard.braun2@gmx.de>

--- a/GitHub_Latest.user.js
+++ b/GitHub_Latest.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        GitHub Latest
 // @namespace   https://github.com/Ede123/userscripts
-// @version     1.0.8
+// @version     1.1.0
 // @description Always keep an eye on the latest activity of your favorite projects
 // @icon        https://raw.githubusercontent.com/Ede123/userscripts/master/icons/GitHub.png
 // @author      Eduard Braun <eduard.braun2@gmx.de>
@@ -12,9 +12,9 @@
 
 
 // redirect link to automatically sort "your stars" by "recently active"
-document.body.addEventListener('mousedown', function(e){
+document.body.addEventListener('mousedown', function (e) {
     var targ = e.target || e.srcElement;
-    if ( targ && targ.href && targ.href.match(/tab=stars$/) ) {
+    if (targ && targ.href && targ.href.match(/tab=stars$/)) {
         targ.href = targ.href.replace(/tab=stars$/, "tab=stars&sort=updated");
     }
 });
@@ -26,10 +26,10 @@ function addLatestButton() {
         return;
     }
 
-    var reponav = document.getElementsByClassName("reponav");
-    if (reponav && (reponav = reponav[0])) {
-        var reponav_list = reponav.firstElementChild;
+    var reponav_list = document.querySelector("nav.js-repo-nav > ul");
+    if (reponav_list) {
         var list_item_issues_copy = reponav_list.children[1].cloneNode(true);
+        list_item_issues_copy.style.marginLeft = "auto";
 
         var button = list_item_issues_copy.firstElementChild;
         button.id = "latest-button"
@@ -39,10 +39,12 @@ function addLatestButton() {
         // unselect
         button.classList.remove("selected");
         button.removeAttribute("data-selected-links");
+        button.removeAttribute("aria-current");
 
         // adjust icon
-        button.firstElementChild.firstElementChild.setAttribute("class","octicon octicon-flame");
-        button.firstElementChild.firstElementChild.firstChild.setAttribute("d","M5.05 0.31c0.81 2.17 0.41 3.38-0.52 4.31-0.98 1.05-2.55 1.83-3.63 3.36-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-0.3-6.61-0.61 2.03 0.53 3.33 1.94 2.86 1.39-0.47 2.3 0.53 2.27 1.67-0.02 0.78-0.31 1.44-1.13 1.81 3.42-0.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52 0.13-2.03 1.13-1.89 2.75 0.09 1.08-1.02 1.8-1.86 1.33-0.67-0.41-0.66-1.19-0.06-1.78 1.25-1.23 1.75-4.09-1.88-6.22l-0.02-0.02z");
+        var icon = button.firstElementChild.firstElementChild;
+        icon.setAttribute("class", icon.getAttribute("class").replace("octicon-issue-opened", "octicon-flame"));
+        icon.firstChild.setAttribute("d", "M5.05 0.31c0.81 2.17 0.41 3.38-0.52 4.31-0.98 1.05-2.55 1.83-3.63 3.36-1.45 2.05-1.7 6.53 3.53 7.7-2.2-1.16-2.67-4.52-0.3-6.61-0.61 2.03 0.53 3.33 1.94 2.86 1.39-0.47 2.3 0.53 2.27 1.67-0.02 0.78-0.31 1.44-1.13 1.81 3.42-0.59 4.78-3.42 4.78-5.56 0-2.84-2.53-3.22-1.25-5.61-1.52 0.13-2.03 1.13-1.89 2.75 0.09 1.08-1.02 1.8-1.86 1.33-0.67-0.41-0.66-1.19-0.06-1.78 1.25-1.23 1.75-4.09-1.88-6.22l-0.02-0.02z");
 
         // remove counter
         var counter = button.getElementsByClassName('counter')[0] || button.getElementsByClassName('Counter')[0];


### PR DESCRIPTION
As part of Feature preview, GitHub is trying another design update:

![](https://user-images.githubusercontent.com/55841/84302564-c5f59f80-ab55-11ea-80ae-e446cad1e3b4.png)

This PR will add support for both "new" and "old" design:

![](https://user-images.githubusercontent.com/55841/84302696-05bc8700-ab56-11ea-8aee-efc32b882042.png)

![](https://user-images.githubusercontent.com/55841/84302640-ea517c00-ab55-11ea-99ef-259a80a46341.png)